### PR TITLE
Treat key combination together with shift key as another event

### DIFF
--- a/src/Ractive-events-keys.js
+++ b/src/Ractive-events-keys.js
@@ -66,7 +66,7 @@
 			node.addEventListener( 'keydown', keydownHandler = function ( event ) {
 				var which = event.which || event.keyCode;
 
-				if ( which === code ) {
+				if ( which === code && !event.shiftKey) {
 					event.preventDefault();
 
 					fire({


### PR DESCRIPTION
I have a case where I have bind on-enter on a textarea-tag (`<textarea on-enter="enter"></textarea>`) and I want it to only trigger when you press `enter` and not `shift+enter`. Where in this case with textarea my events on enter will submit a form and shift+enter will get newline in the textarea.
