### PR TITLE
Different versions of ractive in browserify environment causes problems

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
 	"main": "ractive-events-keys.js",
 	"description": "Key events plugin for Ractive.js",
 	"dependencies": {
-		"ractive": "^0.5.8"
 	},
 	"devDependencies": {
 		"grunt": "~0.4.1",

--- a/ractive-events-keys.js
+++ b/ractive-events-keys.js
@@ -36,7 +36,7 @@
 
 	// Common JS (i.e. browserify) environment
 	if ( typeof module !== 'undefined' && module.exports && typeof require === 'function' ) {
-		factory( require( 'ractive' ) );
+		module.exports = factory;
 	}
 
 	// AMD?


### PR DESCRIPTION
This plugin depends on a specific (old) version of ractive.  When I package up an application using browserify, it packages this old version *and* the version used in my main project.  Not only does this add weight to the bundle, it also means the plugin doesn't work because it registers itself with its own version.

My pull request is a suggested way to deal with this.  In a browserify environment, you would now do:
    
    var Ractive = require('ractive')
    require('ractive-events-keys')(Ractive)

I don't know if this is the best way to fix it, but it seems the easiest at least.